### PR TITLE
Maak aparte beheerpagina’s

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,6 +7,8 @@
         <NuxtLink to="/potworm">Potworm</NuxtLink>
         <NuxtLink to="/trips">Trips</NuxtLink>
         <NuxtLink to="/ziekzoeken">Ziekzoeken</NuxtLink>
+        <NuxtLink to="/leveranciers">Leveranciers</NuxtLink>
+        <NuxtLink to="/soorten">Soorten</NuxtLink>
         <NuxtLink to="/beheer">Beheer</NuxtLink>
       </nav>
     </header>

--- a/pages/leveranciers.vue
+++ b/pages/leveranciers.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+const { data: leveranciers, refresh } = await useFetch('/api/leveranciers')
+
+const editingId = ref<number | null>(null)
+const editName = ref('')
+
+function startEdit(lev: { id: number; naam: string }) {
+  editingId.value = lev.id
+  editName.value = lev.naam
+}
+
+async function saveEdit(id: number) {
+  await $fetch(`/api/leveranciers/${id}`, {
+    method: 'PATCH',
+    body: { naam: editName.value }
+  })
+  editingId.value = null
+  await refresh()
+}
+
+async function remove(id: number) {
+  await $fetch(`/api/leveranciers/${id}`, { method: 'DELETE' })
+  await refresh()
+}
+</script>
+
+<template>
+  <div>
+    <h2>Leveranciers</h2>
+    <ul>
+      <li v-for="lev in leveranciers" :key="lev.id">
+        <div v-if="editingId === lev.id">
+          <input v-model="editName" />
+          <button @click="saveEdit(lev.id)">Opslaan</button>
+          <button @click="editingId = null">Annuleer</button>
+        </div>
+        <div v-else>
+          {{ lev.naam }}
+          <button @click="startEdit(lev)">Bewerk</button>
+          <button @click="remove(lev.id)">Verwijder</button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/pages/soorten.vue
+++ b/pages/soorten.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+const { data: soorten, refresh } = await useFetch('/api/soorten')
+const { data: leveranciers } = await useFetch('/api/leveranciers')
+
+const editingId = ref<number | null>(null)
+const editForm = reactive({ naam: '', leverancierId: '' as number | '' })
+
+function startEdit(s: any) {
+  editingId.value = s.id
+  editForm.naam = s.naam
+  editForm.leverancierId = s.leverancierId
+}
+
+async function saveEdit(id: number) {
+  await $fetch(`/api/soorten/${id}`, {
+    method: 'PATCH',
+    body: {
+      naam: editForm.naam,
+      leverancierId: editForm.leverancierId ? Number(editForm.leverancierId) : undefined
+    }
+  })
+  editingId.value = null
+  await refresh()
+}
+
+async function remove(id: number) {
+  await $fetch(`/api/soorten/${id}`, { method: 'DELETE' })
+  await refresh()
+}
+</script>
+
+<template>
+  <div>
+    <h2>Soorten</h2>
+    <ul>
+      <li v-for="soort in soorten" :key="soort.id">
+        <div v-if="editingId === soort.id">
+          <input v-model="editForm.naam" />
+          <select v-model="editForm.leverancierId">
+            <option v-for="lev in leveranciers" :key="lev.id" :value="lev.id">
+              {{ lev.naam }}
+            </option>
+          </select>
+          <button @click="saveEdit(soort.id)">Opslaan</button>
+          <button @click="editingId = null">Annuleer</button>
+        </div>
+        <div v-else>
+          {{ soort.naam }} - {{ soort.leverancier.naam }}
+          <button @click="startEdit(soort)">Bewerk</button>
+          <button @click="remove(soort.id)">Verwijder</button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/server/api/leveranciers/[id].ts
+++ b/server/api/leveranciers/[id].ts
@@ -1,0 +1,17 @@
+import { prisma } from '../prisma'
+import { z } from 'zod'
+
+const schema = z.object({ naam: z.string().optional() })
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id)
+  if (event.req.method === 'PATCH') {
+    const body = await readBody(event)
+    const data = schema.parse(body)
+    return await prisma.leverancier.update({ where: { id }, data })
+  }
+  if (event.req.method === 'DELETE') {
+    await prisma.leverancier.delete({ where: { id } })
+    return { success: true }
+  }
+})

--- a/server/api/soorten.get.ts
+++ b/server/api/soorten.get.ts
@@ -1,4 +1,7 @@
 import { prisma } from '../prisma'
+
 export default defineEventHandler(async () => {
-  return await prisma.soort.findMany({ select: { id: true, naam: true, leverancier: { select: { naam: true } } } })
+  return await prisma.soort.findMany({
+    select: { id: true, naam: true, leverancierId: true, leverancier: { select: { naam: true } } }
+  })
 })

--- a/server/api/soorten/[id].ts
+++ b/server/api/soorten/[id].ts
@@ -1,0 +1,20 @@
+import { prisma } from '../prisma'
+import { z } from 'zod'
+
+const schema = z.object({
+  naam: z.string().optional(),
+  leverancierId: z.number().optional()
+})
+
+export default defineEventHandler(async (event) => {
+  const id = Number(event.context.params?.id)
+  if (event.req.method === 'PATCH') {
+    const body = await readBody(event)
+    const data = schema.parse(body)
+    return await prisma.soort.update({ where: { id }, data })
+  }
+  if (event.req.method === 'DELETE') {
+    await prisma.soort.delete({ where: { id } })
+    return { success: true }
+  }
+})


### PR DESCRIPTION
## Samenvatting
- voeg API-routes toe voor updaten en verwijderen van leveranciers en soorten
- toon leverancier- en soortenlijsten elk op een eigen pagina
- geef per item bewerk- en verwijderknoppen
- navigeer vanuit de header naar de nieuwe pagina’s
- lever `leverancierId` terug in `soorten.get` zodat bewerken kan

## Testresultaten
- `npm test` *(faalt: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841aea5a5a48327859daecc8cbcf6cf