### PR TITLE
Implement automatic Plant creation

### DIFF
--- a/pages/beheer.vue
+++ b/pages/beheer.vue
@@ -12,29 +12,43 @@ const soortSchema = z.object({ naam: z.string().min(1), leverancierId: z.number(
 
 const leverancierError = ref('')
 const soortError = ref('')
+const leverancierMsg = ref('')
+const soortMsg = ref('')
 
 async function submitLeverancier() {
   leverancierError.value = ''
+  leverancierMsg.value = ''
   const res = leverancierSchema.safeParse(leverancierForm)
   if (!res.success) {
     leverancierError.value = 'Ongeldige invoer'
     return
   }
-  await $fetch('/api/leveranciers', { method: 'POST', body: res.data })
-  await refreshLeveranciers()
-  leverancierForm.naam = ''
+  try {
+    await $fetch('/api/leveranciers', { method: 'POST', body: res.data })
+    await refreshLeveranciers()
+    leverancierForm.naam = ''
+    leverancierMsg.value = 'Toegevoegd'
+  } catch (e) {
+    leverancierError.value = 'Fout bij opslaan'
+  }
 }
 
 async function submitSoort() {
   soortError.value = ''
+  soortMsg.value = ''
   const res = soortSchema.safeParse({ ...soortForm, leverancierId: Number(soortForm.leverancierId) })
   if (!res.success) {
     soortError.value = 'Ongeldige invoer'
     return
   }
-  await $fetch('/api/soorten', { method: 'POST', body: res.data })
-  await Promise.all([refreshSoorten(), refreshLeveranciers()])
-  Object.assign(soortForm, { naam: '', leverancierId: '' })
+  try {
+    await $fetch('/api/soorten', { method: 'POST', body: res.data })
+    await Promise.all([refreshSoorten(), refreshLeveranciers()])
+    Object.assign(soortForm, { naam: '', leverancierId: '' })
+    soortMsg.value = 'Toegevoegd'
+  } catch (e) {
+    soortError.value = 'Fout bij opslaan'
+  }
 }
 </script>
 
@@ -44,6 +58,7 @@ async function submitSoort() {
     <form class="form-box" @submit.prevent="submitLeverancier">
       <input v-model="leverancierForm.naam" placeholder="naam" required />
       <p style="color:red" v-if="leverancierError">{{ leverancierError }}</p>
+      <p style="color:green" v-if="leverancierMsg">{{ leverancierMsg }}</p>
       <button type="submit">Voeg leverancier toe</button>
     </form>
     <!-- Lijst van bestaande leveranciers verwijderd -->
@@ -56,6 +71,7 @@ async function submitSoort() {
         <option v-for="lev in leveranciers" :key="lev.id" :value="lev.id">{{ lev.naam }}</option>
       </select>
       <p style="color:red" v-if="soortError">{{ soortError }}</p>
+      <p style="color:green" v-if="soortMsg">{{ soortMsg }}</p>
       <button type="submit">Voeg soort toe</button>
     </form>
     <!-- Lijst van bestaande soorten verwijderd -->

--- a/pages/oppotten.vue
+++ b/pages/oppotten.vue
@@ -20,9 +20,11 @@ const schema = z.object({
 })
 
 const error = ref('')
+const message = ref('')
 
 async function submit() {
   error.value = ''
+  message.value = ''
   const result = schema.safeParse({
     ...form,
     rasId: Number(form.rasId)
@@ -31,8 +33,20 @@ async function submit() {
     error.value = 'Ongeldige invoer'
     return
   }
-  await $fetch('/api/oppotten', { method: 'POST', body: result.data })
-  Object.assign(form, { leverweek: '', rasId: '', opgepot: '', weggegooid: '', reden: 'te klein', extraReden: '' })
+  try {
+    await $fetch('/api/oppotten', { method: 'POST', body: result.data })
+    Object.assign(form, {
+      leverweek: '',
+      rasId: '',
+      opgepot: '',
+      weggegooid: '',
+      reden: 'te klein',
+      extraReden: ''
+    })
+    message.value = 'Registratie opgeslagen'
+  } catch (e) {
+    error.value = 'Fout bij opslaan'
+  }
 }
 </script>
 
@@ -49,6 +63,7 @@ async function submit() {
     </select>
     <input v-if="form.reden === 'anders'" v-model="form.extraReden" placeholder="extra reden" />
     <p style="color:red" v-if="error">{{ error }}</p>
+    <p style="color:green" v-if="message">{{ message }}</p>
     <button type="submit">Verstuur</button>
   </form>
 </template>

--- a/pages/potworm.vue
+++ b/pages/potworm.vue
@@ -17,16 +17,28 @@ const schema = z.object({
 })
 
 const error = ref('')
+const message = ref('')
 
 async function submit() {
   error.value = ''
+  message.value = ''
   const result = schema.safeParse(form)
   if (!result.success) {
     error.value = 'Ongeldige invoer'
     return
   }
-  await $fetch('/api/potworm', { method: 'POST', body: result.data })
-  Object.assign(form, { jaar: currentYear, week: '', afdeling1: '', afdeling16: '' })
+  try {
+    await $fetch('/api/potworm', { method: 'POST', body: result.data })
+    Object.assign(form, {
+      jaar: currentYear,
+      week: '',
+      afdeling1: '',
+      afdeling16: ''
+    })
+    message.value = 'Registratie opgeslagen'
+  } catch (e) {
+    error.value = 'Fout bij opslaan'
+  }
 }
 </script>
 
@@ -37,6 +49,7 @@ async function submit() {
     <input v-model="form.afdeling1" type="number" placeholder="afdeling1" required />
     <input v-model="form.afdeling16" type="number" placeholder="afdeling16" required />
     <p style="color:red" v-if="error">{{ error }}</p>
+    <p style="color:green" v-if="message">{{ message }}</p>
     <button type="submit">Verstuur</button>
   </form>
 </template>

--- a/pages/trips.vue
+++ b/pages/trips.vue
@@ -20,9 +20,11 @@ const schema = z.object({
 })
 
 const error = ref('')
+const message = ref('')
 
 async function submit() {
   error.value = ''
+  message.value = ''
   const result = schema.safeParse({
     ...form,
     rasId: Number(form.rasId)
@@ -31,8 +33,20 @@ async function submit() {
     error.value = 'Ongeldige invoer'
     return
   }
-  await $fetch('/api/trips', { method: 'POST', body: result.data })
-  Object.assign(form, { leverweek: '', oppotweek: '', rasId: '', aantal: '', locatieX: '', locatieY: '' })
+  try {
+    await $fetch('/api/trips', { method: 'POST', body: result.data })
+    Object.assign(form, {
+      leverweek: '',
+      oppotweek: '',
+      rasId: '',
+      aantal: '',
+      locatieX: '',
+      locatieY: ''
+    })
+    message.value = 'Registratie opgeslagen'
+  } catch (e) {
+    error.value = 'Fout bij opslaan'
+  }
 }
 </script>
 
@@ -45,6 +59,7 @@ async function submit() {
     <input v-model="form.locatieX" placeholder="locatieX" type="number" required />
     <input v-model="form.locatieY" placeholder="locatieY" type="number" required />
     <p style="color:red" v-if="error">{{ error }}</p>
+    <p style="color:green" v-if="message">{{ message }}</p>
     <button type="submit">Verstuur</button>
   </form>
 </template>

--- a/pages/ziekzoeken.vue
+++ b/pages/ziekzoeken.vue
@@ -18,9 +18,11 @@ const schema = z.object({
 })
 
 const error = ref('')
+const message = ref('')
 
 async function submit() {
   error.value = ''
+  message.value = ''
   const result = schema.safeParse({
     ...form,
     rasId: Number(form.rasId)
@@ -29,11 +31,22 @@ async function submit() {
     error.value = 'Ongeldige invoer'
     return
   }
-  await $fetch('/api/ziekzoeken', {
-    method: 'POST',
-    body: result.data
-  })
-  Object.assign(form, { leverweek: '', rasId: '', weggegooid: '', reden: 'te klein', extraReden: '' })
+  try {
+    await $fetch('/api/ziekzoeken', {
+      method: 'POST',
+      body: result.data
+    })
+    Object.assign(form, {
+      leverweek: '',
+      rasId: '',
+      weggegooid: '',
+      reden: 'te klein',
+      extraReden: ''
+    })
+    message.value = 'Registratie opgeslagen'
+  } catch (e) {
+    error.value = 'Fout bij opslaan'
+  }
 }
 </script>
 
@@ -49,6 +62,7 @@ async function submit() {
     </select>
     <input v-if="form.reden === 'anders'" v-model="form.extraReden" placeholder="extra reden" />
     <p style="color:red" v-if="error">{{ error }}</p>
+    <p style="color:green" v-if="message">{{ message }}</p>
     <button type="submit">Verstuur</button>
   </form>
 </template>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,8 @@ model Plant {
 
   createdAt DateTime @default(now())
   gas       gas[]
+
+  @@unique([soortId, leverweek])
 }
 
 model Soort {

--- a/server/api/oppotten.post.ts
+++ b/server/api/oppotten.post.ts
@@ -13,6 +13,23 @@ const schema = z.object({
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const data = schema.parse(body)
-  const record = await prisma.oppotten.create({ data })
+
+  const plant = await prisma.plant.upsert({
+    where: { soortId_leverweek: { soortId: data.rasId, leverweek: data.leverweek } },
+    update: {},
+    create: { soortId: data.rasId, leverweek: data.leverweek }
+  })
+
+  const record = await prisma.oppotten.create({
+    data: {
+      plantId: plant.id,
+      leverweek: data.leverweek,
+      soortId: data.rasId,
+      aantalOpgepot: data.opgepot,
+      aantalWeggooi: data.weggegooid,
+      redenWeggooi: data.reden,
+      andereReden: data.extraReden
+    }
+  })
   return record
 })

--- a/server/api/trips.post.ts
+++ b/server/api/trips.post.ts
@@ -13,6 +13,22 @@ const schema = z.object({
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const data = schema.parse(body)
-  const record = await prisma.trip.create({ data })
+
+  const plant = await prisma.plant.upsert({
+    where: { soortId_leverweek: { soortId: data.rasId, leverweek: data.leverweek } },
+    update: {},
+    create: { soortId: data.rasId, leverweek: data.leverweek }
+  })
+
+  const record = await prisma.trips.create({
+    data: {
+      plantId: plant.id,
+      soortId: data.rasId,
+      leverweek: data.leverweek,
+      oppotweek: data.oppotweek,
+      aantalPlanten: data.aantal,
+      locatie: { x: data.locatieX, y: data.locatieY }
+    }
+  })
   return record
 })

--- a/server/api/ziekzoeken.post.ts
+++ b/server/api/ziekzoeken.post.ts
@@ -12,6 +12,22 @@ const schema = z.object({
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const data = schema.parse(body)
-  const record = await prisma.ziekZoeken.create({ data })
+
+  const plant = await prisma.plant.upsert({
+    where: { soortId_leverweek: { soortId: data.rasId, leverweek: data.leverweek } },
+    update: {},
+    create: { soortId: data.rasId, leverweek: data.leverweek }
+  })
+
+  const record = await prisma.ziekZoeken.create({
+    data: {
+      plantId: plant.id,
+      soortId: data.rasId,
+      leverweek: data.leverweek,
+      aantalWeggooi: data.weggegooid,
+      redenWeggooi: data.reden,
+      andereReden: data.extraReden
+    }
+  })
   return record
 })


### PR DESCRIPTION
## Summary
- enforce unique Plant combinations with soortId and leverweek
- when registering oppotten, trips or ziekzoeken, create or reuse a Plant and store the plantId

## Testing
- `npm install`
- `npm run db:generate`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841c36e956c8327975931b3f30c8bd3