### PR TITLE
Add minimal Flutter Spotify QR player sample

### DIFF
--- a/spotify_qr_player/README.md
+++ b/spotify_qr_player/README.md
@@ -1,0 +1,12 @@
+# Spotify QR Player
+
+Minimal Flutter app that scans a QR code containing a Spotify track URL and plays it on the user's active device using the Spotify Web API.
+
+## Usage
+1. Replace `YOUR_CLIENT_ID` and `redirectUri` in `lib/main.dart` with your Spotify app credentials.
+2. Run `flutter pub get`.
+3. Launch the app on a device with Spotify installed and logged in.
+4. Press **Scan QR** and scan a code like `https://open.spotify.com/track/<id>`.
+5. The track starts playing on your active Spotify device.
+
+No track metadata is shown, only a status message.

--- a/spotify_qr_player/lib/main.dart
+++ b/spotify_qr_player/lib/main.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_barcode_scanner/flutter_barcode_scanner.dart';
+import 'package:flutter_web_auth/flutter_web_auth.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'Spotify QR Player',
+      home: HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  String? _accessToken;
+  String _status = '';
+
+  static const String clientId = 'YOUR_CLIENT_ID';
+  static const String redirectUri = 'yourapp://callback';
+  static const String scopes = 'user-read-playback-state user-modify-playback-state streaming';
+
+  Future<void> _authenticate() async {
+    final url = Uri.https('accounts.spotify.com', '/authorize', {
+      'client_id': clientId,
+      'response_type': 'token',
+      'redirect_uri': redirectUri,
+      'scope': scopes,
+    });
+    final result = await FlutterWebAuth.authenticate(url: url.toString(), callbackUrlScheme: 'yourapp');
+    final fragment = Uri.parse(result).fragment;
+    final token = Uri.splitQueryString(fragment)['access_token'];
+    setState(() => _accessToken = token);
+  }
+
+  Future<void> _scanAndPlay() async {
+    if (_accessToken == null) {
+      await _authenticate();
+      if (_accessToken == null) return;
+    }
+    final qr = await FlutterBarcodeScanner.scanBarcode('#ff6666', 'Cancel', true, ScanMode.QR);
+    if (!qr.startsWith('https://open.spotify.com/track/')) {
+      setState(() => _status = 'Geen geldige Spotify tracklink');
+      return;
+    }
+    final trackId = Uri.parse(qr).pathSegments.last;
+    final ok = await _playTrack(trackId);
+    setState(() => _status = ok ? '🎧 Track speelt af…' : 'Open Spotify op actief apparaat');
+  }
+
+  Future<bool> _playTrack(String trackId) async {
+    final res = await http.put(
+      Uri.parse('https://api.spotify.com/v1/me/player/play'),
+      headers: {
+        'Authorization': 'Bearer $_accessToken',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({'uris': ['spotify:track:$trackId']}),
+    );
+    return res.statusCode == 204;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Spotify QR Player')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: _scanAndPlay,
+              child: const Text('Scan QR'),
+            ),
+            const SizedBox(height: 20),
+            Text(_status),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/spotify_qr_player/pubspec.yaml
+++ b/spotify_qr_player/pubspec.yaml
@@ -1,0 +1,20 @@
+name: spotify_qr_player
+description: Minimal app to scan QR and play Spotify track.
+version: 1.0.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_barcode_scanner: ^2.0.0
+  flutter_web_auth: ^0.3.2
+  http: ^0.13.4
+  url_launcher: ^6.1.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add minimal Flutter app `spotify_qr_player`
- implement OAuth login, QR scanner and playback request
- include instructions in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec77c80bc8327b11da244acfca2b8